### PR TITLE
Expose functionallity as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+
+pub mod cidr;
+pub mod hosts;
+pub mod icmp;
+pub mod ports;
+
+pub use cidr::IpAddrRange;
+pub use crate::hosts::{probe_host, HostStatus};
+pub use crate::ports::{probe_port, PortStatus};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
-mod cidr;
-mod hosts;
-mod icmp;
-mod ports;
-
-use crate::cidr::IpAddrRange;
-use crate::hosts::{probe_host, HostStatus};
-use crate::ports::{probe_port, PortStatus};
+use rustmap::{
+    IpAddrRange,
+    probe_port,
+    probe_host,
+    HostStatus,
+    PortStatus,
+};
 use parse_duration;
 use std::io::{self, Write};
 use std::net::SocketAddr;


### PR DESCRIPTION
Since this is published on crates.io, it would be nice to expose the inner workings as a library.

This is a naive approach to that end, simply making all of the existing modules public and explicitly exposing the items used by in main.rs in a lib.rs file. 